### PR TITLE
[Mijeong] Chapter8 question16-19

### DIFF
--- a/ch8/cmj_16_add_two_numbers.py
+++ b/ch8/cmj_16_add_two_numbers.py
@@ -1,0 +1,35 @@
+# Definition for singly-linked list.
+# class ListNode:
+#     def __init__(self, val=0, next=None):
+#         self.val = val
+#         self.next = next
+class Solution:
+    def addTwoNumbers(self, l1: Optional[ListNode], l2: Optional[ListNode]) -> Optional[ListNode]:
+        p = l1
+        q = l2
+        quo = 0         # 몫
+            
+        next_node = l1
+        
+        while p or q or quo:
+            sum_ = 0
+            x = p.val if p else 0
+            y = q.val if q else 0
+
+            sum_ = x+y + quo
+            quo = (x+y+quo)//10
+
+            if quo > 0:        # 몫이 있으면 현재 노드의 val을 나머지값으로 갱신
+                next_node.val = sum_%10
+            else:
+                next_node.val = sum_
+
+            p = p.next if p else None
+            q = q.next if q else None
+            
+            if p==None and q==None and quo==0:      # 연결 리스트가 모두 None인데 몫도 없으면 break
+                break
+            next_node.next = ListNode(quo)         # 몫이 있거나, 연결 리스트가 둘 중 하나라도 존재하는 경우
+            next_node = next_node.next
+
+        return l1

--- a/ch8/cmj_17_swap_nodes_in_pairs.py
+++ b/ch8/cmj_17_swap_nodes_in_pairs.py
@@ -1,0 +1,14 @@
+# Definition for singly-linked list.
+# class ListNode:
+#     def __init__(self, val=0, next=None):
+#         self.val = val
+#         self.next = next
+class Solution:
+    def swapPairs(self, head: Optional[ListNode]) -> Optional[ListNode]:
+        node = head
+
+        while node and node.next:
+            node.val, node.next.val = node.next.val, node.val         # 앞 뒤 값을 교체
+            node = node.next.next           # 두 칸씩 뜀
+
+        return head

--- a/ch8/cmj_18_odd_even_linked_list.py
+++ b/ch8/cmj_18_odd_even_linked_list.py
@@ -1,0 +1,24 @@
+# Definition for singly-linked list.
+# class ListNode:
+#     def __init__(self, val=0, next=None):
+#         self.val = val
+#         self.next = next
+class Solution:
+    def oddEvenList(self, head: Optional[ListNode]) -> Optional[ListNode]:
+        if head is None:
+            return None
+
+        odd_pointer = head
+        even_pointer = head.next
+
+        even_head = head.next        #### 짝수번째 노드의 헤드를 기억
+
+        while even_pointer and even_pointer.next:
+            odd_pointer.next, even_pointer.next = odd_pointer.next.next, even_pointer.next.next
+            odd_pointer = odd_pointer.next
+            even_pointer = even_pointer.next
+        
+        # 홀수번째 노드와 연결
+        odd_pointer.next = even_head
+
+        return head

--- a/ch8/cmj_19_reverse_linked_list2.py
+++ b/ch8/cmj_19_reverse_linked_list2.py
@@ -5,6 +5,25 @@
 #         self.next = next
 class Solution:
     def reverseBetween(self, head: Optional[ListNode], left: int, right: int) -> Optional[ListNode]:
+        # 예외 처리
+        if not head or left == right:
+            return head
+
+        root = start = ListNode(None)
+        root.next = head
+        # start, end 지정
+        for _ in range(left - 1):
+            start = start.next
+        end = start.next
+
+        # 반복하면서 노드 차례대로 뒤집기
+        for _ in range(right - left):  ## 이해가 안돼요
+            tmp, start.next, end.next = start.next, end.next, end.next.next
+            start.next.next = tmp
+
+        return root.next
+    
+    def reverseBetween2(self, head: Optional[ListNode], left: int, right: int) -> Optional[ListNode]:
         # 구간 길이가 0인 경우 그냥 리턴
         if left == right:
             return head

--- a/ch8/cmj_19_reverse_linked_list2.py
+++ b/ch8/cmj_19_reverse_linked_list2.py
@@ -1,0 +1,45 @@
+# Definition for singly-linked list.
+# class ListNode:
+#     def __init__(self, val=0, next=None):
+#         self.val = val
+#         self.next = next
+class Solution:
+    def reverseBetween(self, head: Optional[ListNode], left: int, right: int) -> Optional[ListNode]:
+        # 구간 길이가 0인 경우 그냥 리턴
+        if left == right:
+            return head
+
+        curr = head
+        front = head        # 왼쪽 부분의 head
+        count = 1
+        left_count = 1
+        
+        while count < left:
+            curr = curr.next
+            count += 1
+            left_count += 1
+
+        # left부터 right reverse
+        prev = None
+        while count <= right and curr:
+            next_node, curr.next = curr.next, prev
+            prev, curr = curr, next_node
+            count += 1
+
+        result = prev
+
+        # 오른쪽 원소들과 연결
+        while prev and prev.next:
+            prev = prev.next
+        prev.next = next_node
+
+        if left > 1:
+            left_front = front
+            while left > 2 and front and front.next:
+                left -= 1
+                front = front.next
+
+            front.next = result        # 왼쪽 원소들과 연결
+            return left_front
+
+        return result


### PR DESCRIPTION
### 16. 두 수의 덧셈
문제 설명: 두 연결리스트 원소의 합을 연결리스트로 리턴하는 문제 (단, 덧셈의 올림도 구현)
문제 풀이: 30분

풀이 방식
- p, q: 각 연결리스트에서 현재 원소를 가리키는 포인터.
- next_node: list1의 값을 조작하는 포인터
- (연결리스트 두 원소의 합 + 올림수)로 next_node의 값 갱신
&nbsp; - 올림수가 있으면: next_node의 값 = (연결리스트 두 원소의 합 + 올림수) 를 10으로 나눈 나머지
&nbsp; - 올림수가 없으면: next_node의 값 = (연결리스트 두 원소의 합 + 올림수)
- divmod(나눠지는 수, 나누는 수 ): 몫과 나머지를 계산하는 내장함수
<br>

### 17. 페어의 노드 스왑
문제 설명: 연결리스트에서 각 페어의 원소를 스왑하는 문제 
e.g.) [a, b, c, d] -> 페어: (a, b) (c, d) -> (b, a) (d, c) => [b, a, d, c]
문제 풀이: 40분

풀이 방식
- 앞뒤로 값을 교환하고, 노드를 두 칸씩 이동
<br>

### 18. 홀짝 연결리스트
문제 설명: 연결리스트를 [모든 홀수 인덱스 원소, 모든 짝수인덱스 원소] 형태로 만드는 문제
e.g.) [2, 3, 4, 5, 6] -> 홀수 인덱스 원소: [2, 4, 6], 짝수 인덱스 원소: [3, 5] => [2, 4, 6, 3, 5]
문제 미해결

풀이 방식
- 홀/짝 원소를 가리키는 포인터를 두고 노드를 이동시키면서 홀/짝 원소를 가리키는 포인터 갱신
- 갱신이 끝나면, 홀수 포인터의 마지막에 짝수 원소의 head를 연결

- odd_pointer: 홀수번째 원소를 가리키는 포인터
- even_pointer: 짝수번째 원소를 가리키는 포인터
- **even_head: 짝수번째 원소들의 head를 가리키는 포인터**
<br>

### 19. 역순 연결 리스트2
문제 설명: 연결리스트 위치 left, right이 주어질 때 주어진 구간의 원소를 역순으로 만드는 문제
문제 해결: 50분...

풀이 방식
- 노드를 left까지 이동시킴
- left부터 right 구간의 원소를 뒤집음 (역순 연결 리스트1)
- 현재 연결 리스트에 오른쪽 부분(next_node)과 왼쪽 부분(front)을 연결