### PR TITLE
[Mijeong] chapter9 question22-25

### DIFF
--- a/ch9/cmj_22_daily_temperatures.py
+++ b/ch9/cmj_22_daily_temperatures.py
@@ -1,0 +1,37 @@
+class Solution:
+    def dailyTemperatures(self, temperatures: List[int]) -> List[int]:
+        st = []
+        result = [0] * len(temperatures)
+
+        for i in range(len(temperatures)):
+            while st and temperatures[i] > temperatures[st[-1]]:        # 현재 온도가 스택의 top보다 더 높다면
+                current = st.pop()
+                result[current] = i-current
+            st.append(i)     # 스택에 현재 값의 인덱스를 저장
+        
+        return result
+    
+'''
+    def dailyTemperatures(self, temperatures: List[int]) -> List[int]:
+        queue = []
+        result = []
+
+        for i in range(len(temperatures)):
+            queue.append(temperatures[i])
+
+            while len(queue) >= 2 and queue[0] < queue[-1]:
+                queue.pop(0)
+                result.append(len(queue))
+
+        for i in range(len(temperatures)-len(result)):
+            result.append(0)
+
+        return result
+        
+    아래의 경우에서 오답이 나옴
+    Input
+    temperatures = [73,74,75,71,69,72,76,73]
+
+    Output [1,1,4,3,2,1,0,0]
+    Expected [1,1,4,2,1,1,0,0]
+'''

--- a/ch9/cmj_23_implement_stack_using_queues.py
+++ b/ch9/cmj_23_implement_stack_using_queues.py
@@ -1,0 +1,19 @@
+class MyStack:
+    def __init__(self):
+        self.q1 = []       # push하는 큐
+        self.q2 = []       # pop하는 큐
+
+    def push(self, x: int) -> None:
+        self.q1.append(x)
+        self.q2 = self.q1[::-1]        # pop 하는 큐는 기존 큐의 역순, 맨 앞 원소가 스택의 맨 위가 됨
+
+    def pop(self) -> int:
+        pop_item = self.q2.pop(0)      # 맨 앞 원소(여기서는 스택의 top)를 pop
+        self.q1 = self.q2[::-1]        # pop한 내용을 q1에도 저장
+        return pop_item
+
+    def top(self) -> int:
+        return self.q2[0]
+
+    def empty(self) -> bool:
+        return len(self.q2) == 0

--- a/ch9/cmj_24_implement_queue_using_stacks.py
+++ b/ch9/cmj_24_implement_queue_using_stacks.py
@@ -1,0 +1,22 @@
+class MyQueue:
+    
+    def __init__(self):
+        self.st1 = []         
+        self.st2 = []
+
+    def push(self, x: int) -> None:
+        self.st1.append(x)
+
+    def pop(self) -> int:
+        self.peek()          ### peek() 호출해서 st2에 원소 추가. 안하면 st2가 비어있는 경우 runtime error 발생
+        return self.st2.pop()
+
+    def peek(self) -> int:
+        if not self.st2:           # 초기에 큐가 비어있을 때뿐만 아니라, 중간에 새로운 원소가 push되고 pop할 때 기존에 있던 원소들을 먼저 pop한 뒤 중간에 push된 원소를 pop하도록 함
+            for _ in range(len(self.st1)):
+                self.st2.append(self.st1.pop())
+    
+        return self.st2[-1]
+
+    def empty(self) -> bool:
+        return len(self.st1) == 0 and len(self.st2) == 0

--- a/ch9/cmj_25_design_circular_queue.py
+++ b/ch9/cmj_25_design_circular_queue.py
@@ -1,0 +1,81 @@
+class MyCircularQueue:
+    
+    def __init__(self, k: int):
+        self.q = [None] * k
+        self.q_len = k
+        self.front_pointer = 0         # 앞 원소를 가리키는 포인터
+        self.rear_pointer = 0          # 뒤 원소를 가리키는 포인터
+
+    def enQueue(self, value: int) -> bool:
+        if self.q[self.rear_pointer] is None:          # 포인터가 가리키는 큐가 비어있을 때
+            self.q[self.rear_pointer] = value
+            print(self.rear_pointer, self.q[self.rear_pointer])
+            self.rear_pointer = (self.rear_pointer+1) % self.q_len       # rear pointer 이동
+            return True
+        return False
+
+    def deQueue(self) -> bool:
+        if self.q[self.front_pointer] is not None:
+            self.q[self.front_pointer] = None
+            self.front_pointer = (self.front_pointer+1)%self.q_len       # front pointer 이동
+            return True
+        return False
+        
+    def Front(self) -> int:
+        if self.q[self.front_pointer] is not None:
+            return self.q[self.front_pointer]
+        return -1
+
+    def Rear(self) -> int:
+        if self.q[self.rear_pointer-1] is None:
+            return -1
+        
+        return self.q[self.rear_pointer-1]
+
+    def isEmpty(self) -> bool:
+        return self.front_pointer == self.rear_pointer and self.q[self.front_pointer] is None      # 초기상태 혹은 deque를 많이 해서 빈 경우
+
+    def isFull(self) -> bool:
+        return self.front_pointer == self.rear_pointer and self.q[self.front_pointer] is not None
+    
+'''
+76 ms
+
+class MyCircularQueue:
+    
+    def __init__(self, k: int):
+        self.q = []
+        self.q_len = k                     # 큐의 크기
+        self.rear_pointer = 0              # rear 위치
+
+    def enQueue(self, value: int) -> bool:
+        if len(self.q) < self.q_len:
+            self.q.append(value)
+            return True
+        return False
+
+    def deQueue(self) -> bool:
+        if len(self.q) > 0:
+            self.q.pop(0)
+            return True
+        return False
+
+    def Front(self) -> int:
+        if self.q:
+            return self.q[0]
+        return -1
+
+    def Rear(self) -> int:
+        if not self.q:
+            return -1
+        self.rear_pointer = 0
+        while self.rear_pointer < len(self.q): 
+            self.rear_pointer += 1
+        return self.q[self.rear_pointer-1]
+
+    def isEmpty(self) -> bool:
+        return len(self.q) == 0
+
+    def isFull(self) -> bool:
+        return len(self.q) == self.q_len
+'''


### PR DESCRIPTION
### 22. 일일 온도
문제 설명: 일일 온도가 리스트로 주어질 때, i번째 날보다 따뜻한 날은 얼마나 기다려야하는지 구하는 문제
문제 미해결

풀이 방식
- 첫 시도: 큐에 원소를 넣고, queue[0] < queue[-1]인 경우(최근 큐에 들어온 온도가 더 높은 경우) queue[0]를 큐에서 제거하고 큐의 사이즈를 결과 리스트에 저장
-> 큐의 중간(queue[0]과 queue[-1] 사이)에 queue[0]보다 큰 원소가 존재할 경우를 캐치하지 못함
-> list.index()로 중간에 큰 원소가 존재하는 경우를 판단하려고 했으나 list.index()는 중복된 값이 있을 경우 처리를 하지 못함

느낀점
- 책의 풀이처럼 그냥 for문에서 인덱스를 비교했으면 됐을텐데...왜 이렇게 풀었을까
<br>

### 23-24. 큐를 이용한 스택 구현 / 스택을 이용한 큐 구현
문제 풀이: 각각 20분

풀이 방식
- 두 문제 다 push와 pop을 하는 큐/스택을 따로 둬서 풀었음
- 23번: 큐1에 push한 뒤, 큐2에 이를 역순으로 저장(q2 = q1[::-1]) 큐2에서 pop한 뒤, 큐1에 이를 저장(q1 = q2[::-1])
- 24번: pop할 때 스택2에 스택1 원소를 추가 (어쨋든 역순으로 저장됨)

참고
- collections.deque(): 앞/뒤에서 push/pop이 가능한 양방향 큐
  - append(), appendleft()
  - pop(), popleft()
<br>

### 25. 원형 큐 디자인
문제 설명: 마지막 위치가 시작 위치와 연결되는 원형 큐 만들기
문제 풀이: 30분

풀이 방식
- 내 풀이: rear를 가리키는 rear_pointer 사용. 그 외에는 기본적으로 큐 연산. 답은 맞았으나 원형 큐라고 보기에는 애매...한 코드
- 책의 풀이: front와 rear를 각각 가리키는 포인터 사용. Enque를 할 때 rear pointer를, Deque를 할 때 front pointer를 이동. 모듈러 연산 사용

느낀점
- 문제만 봤을 때는 원형 큐를 만들지 않아도 풀 수 있어서 감을 잘 못 잡았던 것 같다. 원형 큐라는 걸 잊고 있었는데 이번 기회에 잘 기억해놔야겠다.
