### PR TITLE
[Mijeong] chapter14 question45-48

### DIFF
--- a/ch14/cmj_45_invert_binary_tree.py
+++ b/ch14/cmj_45_invert_binary_tree.py
@@ -1,0 +1,31 @@
+# Definition for a binary tree node.
+# class TreeNode:
+#     def __init__(self, val=0, left=None, right=None):
+#         self.val = val
+#         self.left = left
+#         self.right = right
+class Solution:
+    def invertTree(self, root: Optional[TreeNode]) -> Optional[TreeNode]:
+        result = root
+        def swap(node):
+            if not node:
+                return
+
+            node.left, node.right = swap(node.right), swap(node.left)
+            return node
+            
+        swap(root)
+        return result
+    
+    # 방법2. 스택 이용
+    def invertTree(self, root: Optional[TreeNode]) -> Optional[TreeNode]:
+        stack = [root]
+
+        while stack:
+            node = stack.pop()
+            if node:
+                node.left, node.right = node.right, node.left
+                stack.append(node.left)
+                stack.append(node.right)
+        
+        return root

--- a/ch14/cmj_46_merge_two_binary_trees.py
+++ b/ch14/cmj_46_merge_two_binary_trees.py
@@ -1,0 +1,15 @@
+# Definition for a binary tree node.
+# class TreeNode:
+#     def __init__(self, val=0, left=None, right=None):
+#         self.val = val
+#         self.left = left
+#         self.right = right
+class Solution:
+    def mergeTrees(self, root1: Optional[TreeNode], root2: Optional[TreeNode]) -> Optional[TreeNode]:
+        if root1 and root2:
+            node = TreeNode(root1.val + root2.val)
+            node.left = self.mergeTrees(root1.left, root2.left)
+            node.right = self.mergeTrees(root1.right, root2.right)
+            return node
+        else:
+            return root1 or root2

--- a/ch14/cmj_47_serialize_and_deserialize_binary_tree.py
+++ b/ch14/cmj_47_serialize_and_deserialize_binary_tree.py
@@ -1,0 +1,94 @@
+import collections
+
+# Definition for a binary tree node.
+# class TreeNode(object):
+#     def __init__(self, x):
+#         self.val = x
+#         self.left = None
+#         self.right = None
+
+class Codec:
+    i=0
+    def serialize(self, root):
+        """Encodes a tree to a single string.
+        
+        :type root: TreeNode
+        :rtype: str
+        """
+
+        def bfs(node):
+            queue = [node]
+            serialized = []
+            while queue:
+                new_node = queue.pop(0)
+                if new_node:
+                    queue.append(new_node.left)
+                    queue.append(new_node.right)
+
+                    serialized.append(str(new_node.val))
+                else:
+                    serialized.append('#')
+
+            return serialized
+        
+        result = bfs(root)
+        
+        return ' '.join(result)
+
+    def deserialize(self, data):
+        """Decodes your encoded data to tree.
+        
+        :type data: str
+        :rtype: TreeNode
+        """
+        if not any(s.isdigit() for s in data):     # 숫자가 하나도 없으면
+            return None
+
+        nodes = data.split()
+        root = TreeNode(int(nodes[0]))
+        queue = collections.deque([root])
+        index = 1    # 현재 노드의 왼쪽 자식
+
+        # 자식 노드 결과 먼저 확인 후 큐 삽입
+        while queue:
+            node = queue.popleft()
+            if nodes[index] is not '#':       # 왼쪽 자식
+                node.left = TreeNode(int(nodes[index]))
+                queue.append(node.left)
+            index += 1
+
+            if nodes[index] is not '#':       # 오른쪽 자식
+                node.right = TreeNode(int(nodes[index]))
+                queue.append(node.right)
+            index += 1
+        return root
+    
+    # 방법2. dfs
+    def serialize2(self, root):
+
+        result = []
+        def dfs(root):
+            if(root is None):
+                result.append("N")
+                return
+            result.append(str(root.val))
+            dfs(root.left)
+            dfs(root.right)
+        dfs(root)
+        return ' '.join(result)
+        
+
+    def deserialize2(self, data):
+
+        vals = data.split()
+        
+        def dfs():
+            if(vals[self.i] == "N"):
+                self.i += 1
+                return
+            node = TreeNode(vals[self.i])
+            self.i += 1         # 자식 노드 탐색을 위한 인덱스 증가
+            node.left = dfs()
+            node.right = dfs()
+            return node
+        return dfs()

--- a/ch14/cmj_48_balanced_binary_tree.py
+++ b/ch14/cmj_48_balanced_binary_tree.py
@@ -1,0 +1,36 @@
+class Solution:
+    def isBalanced(self, root: Optional[TreeNode]) -> bool:
+        def dfs(node):
+            if not node:
+                return 0
+            
+            left = dfs(node.left)
+            right = dfs(node.right)
+
+            if left == -1 or right == -1 or abs(left-right) > 1:
+                return -1
+            
+            return max(left, right)+1
+        
+        return dfs(root) != -1
+
+    ''' 이진트리 최대 깊이 풀었던 방식으로 시도했으나 실패...
+        219 / 228 testcases passed
+    result = []
+    def isBalanced(self, root: Optional[TreeNode]) -> bool:
+        self.result = []
+
+        def dfs(node, count):
+            if not node:
+                self.result.append(count)
+                return count
+            
+            left_depth = dfs(node.left, count+1)       # 왼쪽 서브트리
+            right_depth = dfs(node.right, count+1)     # 오른쪽 서브트리
+
+            return max(left_depth, right_depth)
+
+        dfs(root, 0)
+        
+        diff = max(self.result) - min(self.result)
+        return diff <= 1'''


### PR DESCRIPTION
### 45. 이진 트리 반전
문제 설명: 주어진 이진 트리의 좌우를 반전시키는 문제 ex) Input: root = [2,1,3] Output: [2,3,1]
문제 풀이: 20분

풀이 방식
- dfs를 이용해 재귀적으로 노드를 방문하면서 왼쪽 자식 노드와 오른쪽 자식 노드를 교환해주면 됨

느낀점
- 나는 tmp 변수를 두고 직접 두 자식 노드의 값을 교환했는데, tmp없이 한 라인으로도 처리가 가능하다는 걸 알게 되었다
<br>

### 46. 두 이진 트리 병합
문제 설명: 두 이진 트리를 병합하는 문제. 양쪽 트리 모두에 노드가 존재하면 해당 노드의 합을, 한쪽에만 존재하면 해당 값을 노드로 만듦
문제 미해결

풀이 방식
- 양쪽 이진 트리에 노드가 존재하면
  - 두 노드의 값을 합친 새로운 노드를 만들고
  - 새 노드의 왼쪽, 오른쪽 노드를 재귀적으로 탐색
- 두 이진 트리 중 하나라도 노드가 존재하지 않으면
  - 존재하는 노드를 리턴
<br>

### 47. 이진 트리 직렬화 & 역직렬화
문제 설명: 주어진 이진 트리를 직렬화, 역직렬화 하는 문제
※ 직렬화: 주어진 데이터 구조를 일련의 비트(여기서는 string)로 변환 
※ 역직렬화: 일련의 비트를 다시 데이터 구조로 변환

문제 미해결

풀이 방식
- bfs/dfs 둘 다 가능
- bfs
  - 직렬화: 자식 노드가 존재하면 큐에 넣고, 결과 string에 현재 노드를 저장
                 자식 노드가 없으면 임의의 문자를 결과 string에 저장(자식이 없음을 알리기 위함)
  - 역직렬화: 큐를 이용해 왼쪽 자식, 오른쪽 자식을 체크함
                     자식 노드 값이 임의의 문자가 아니면, 현재 노드의 왼쪽, 오른쪽 노드에 추가하고 큐에 저장
<br>

### 48. 균형 이진 트리
문제 설명: 주어진 트리의 균형 이진 트리 여부를 구하는 문제
문제 미해결

풀이 방식
- 트리의 왼쪽, 오른쪽 서브 트리를 재귀적으로 탐색하면서
  - 서브 트리 값이 -1이거나 두 서브 트리 높이 차이가 1 보다 클 경우 -1 리턴
  - 아무 문제 없으면, max(left, right)+1을 리턴