### PR TITLE
[Mijeong] chapter14 question 52-54

### DIFF
--- a/ch14/cmj_52_range_sum_of_BST.py
+++ b/ch14/cmj_52_range_sum_of_BST.py
@@ -1,0 +1,19 @@
+class Solution:
+    result = 0
+    def rangeSumBST(self, root: Optional[TreeNode], low: int, high: int) -> int:
+        def dfs(node):
+            if not node:
+                return None
+            
+            if low <= node.val and node.val <= high:
+                self.result += node.val
+            
+            if node.val > low:
+                dfs(node.left)
+            if node.val < high:
+                dfs(node.right)
+
+            return self.result
+        
+        dfs(root)
+        return self.result

--- a/ch14/cmj_53_minimum_distance_between_BST_nodes.py
+++ b/ch14/cmj_53_minimum_distance_between_BST_nodes.py
@@ -1,0 +1,35 @@
+class Solution:
+    def minDiffInBST(self, root: Optional[TreeNode]) -> int:
+        nums = []
+        def inorder(root):          # 중위순회를 이용해 값을 오름차순으로 정렬
+            if root:
+                inorder(root.left)
+                nums.append(root.val)
+                inorder(root.right)
+
+        inorder(root)
+
+        result = nums[1]-nums[0]
+        for i in range(2, len(nums)):
+            result = min(result, nums[i]-nums[i-1])
+
+        return result
+    
+    '''39 / 49 testcases passed
+    result = 1000000
+    def minDiffInBST(self, root: Optional[TreeNode]) -> int:
+        def dfs(node, parent, root):
+            if not node:
+                return None
+            
+            if parent and node:
+                self.result = min(self.result, abs(parent.val-node.val))
+                self.result = min(self.result, abs(root.val-node.val))
+            left = dfs(node.left, node, root)
+            right = dfs(node.right, node, root)
+            
+            return self.result
+
+        dfs(root, None, root)
+        return self.result
+    '''

--- a/ch14/cmj_54_construct_binary_tree_from_preorder_and_inorder_traversal.py
+++ b/ch14/cmj_54_construct_binary_tree_from_preorder_and_inorder_traversal.py
@@ -1,0 +1,11 @@
+class Solution:
+    def buildTree(self, preorder: List[int], inorder: List[int]) -> Optional[TreeNode]:
+        if inorder:
+            idx = inorder.index(preorder.pop(0))
+
+            # 서브트리의 루트/left/right
+            node = TreeNode(inorder[idx])
+            node.left = self.buildTree(preorder, inorder[:idx])
+            node.right = self.buildTree(preorder, inorder[idx+1:])
+
+            return node


### PR DESCRIPTION
### 52. [이진 탐색 트리(BST) 합의 범위](https://leetcode.com/problems/range-sum-of-bst/)
문제 설명: 두 정수 low, high가 주어질 때 [low, high]범위에 해당하는 이진 트리 값의 합을 구하는 문제
문제 풀이: 10분

풀이 방식
- dfs: [low, high] 범위에 해당하는 노드를 만나면 클래스 변수 result에 해당 값을 누적하고 이 결과를 리턴
   - low, high를 이용한 가지치기: 현재 노드값이 low보다 크면 왼쪽 서브트리 탐색, high보다 작으면 오른쪽 서브트리 탐색

느낀점
- 첫 풀이에서는 왼쪽, 오른쪽 서브트리를 그냥 탐색했었는데 low, high를 이용하니 runtime이 133m에서 100m로 줄었다. 재귀에서는 조건을 잘 적용하는 게 중요하다는 걸 다시 깨달았다.
<br>

### 53. [이진 탐색 트리(BST) 노드 간 최소 거리](https://leetcode.com/problems/minimum-distance-between-bst-nodes/)
문제 설명: 이진 트리에서 두 노드 값의 차이가 최소인 경우 구하기
문제 미해결

풀이 방식
- 중위순회(inorder) 이용: 중위순회를 이용해 트리를 오름차순으로 정렬
  - 정렬된 노드들을 방문하면서 최솟값 업데이트
<br>

### 54. [전위, 중위 순회 결과로 이진 트리 구축](https://leetcode.com/problems/construct-binary-tree-from-preorder-and-inorder-traversal/)
문제 설명: 트리의 전위 순회, 중위 순회 결과가 주어질 때, 이를 이용해 이진 트리 구축하기
문제 미해결

풀이 방식
- **분할 정복(divde and conquer)**
  - 전위 순회(preorder): **루트** - 왼쪽 서브트리 - 오른쪽 서브트리 순으로 방문. **서브트리의 루트를 항상 먼저 방문한다는 것을 이용**
  - 중위 순회(inorder): 왼쪽 서브트리 - 루트 - 오른쪽 서브트리 순으로 방문. **전위 순회에서 알아낸 루트를 이용해 왼쪽 서브트리, 오른쪽 서브트리로 쪼갤 수 있음**

느낀점
- 전위 순회를 이용해 루트를 알아내고, 중위 순회를 이용해 서브트리 크기를 알아냈는데 이를 재귀로 어떻게 구현해야 하는지 잘 감이 안잡혔다. 비슷한 문제를 계속 풀어봐야 할 것 같다.

유사한 문제
- [정렬된 배열의 이진 탐색 트리 변환](https://leetcode.com/problems/convert-sorted-array-to-binary-search-tree/)
  - 분할 정복
<br>
