### PR TITLE
[Mijeong] chapter18 question 65-69

### DIFF
--- a/ch18/cmj_65_binary_search.py
+++ b/ch18/cmj_65_binary_search.py
@@ -1,0 +1,14 @@
+class Solution:
+    def search(self, nums: List[int], target: int) -> int:
+        left, right = 0, len(nums)-1
+
+        while left <= right:
+            mid = (left+right)//2
+            if nums[mid] == target:
+                return mid
+            elif nums[mid] < target:
+                left = mid + 1
+            else:
+                right = mid - 1
+    
+        return -1

--- a/ch18/cmj_66_search_in_rotated_sorted_array.py
+++ b/ch18/cmj_66_search_in_rotated_sorted_array.py
@@ -1,0 +1,62 @@
+class Solution:
+    def search(self, nums: List[int], target: int) -> int:
+
+        # 최소값 찾아 피봇 설정
+        left, right = 0, len(nums) - 1
+        while left < right:
+            mid = (left + right) // 2
+            if nums[mid] > nums[right]:         # 회전이 발생한 경우
+                left = mid + 1                 # 구간을 오른쪽으로 이동
+            else:
+                right = mid
+        
+        pivot = left
+        left, right = 0, len(nums)-1
+
+        while left <= right:
+            mid = (left + right)//2
+
+            mid_pivot = (mid+pivot)%len(nums)        ######
+
+            if nums[mid_pivot] < target:
+                left = mid + 1
+            elif nums[mid_pivot] > target:
+                right = mid - 1
+            else:
+                return mid_pivot
+
+        return -1
+    
+    ''' 190 / 195 testcases passed
+    피봇을 찾는 과정과 이진 검색을 한 반복문에서 처리하려고 하다보니 꼬인 것 같다...
+
+    def search(self, nums: List[int], target: int) -> int:
+        if nums[0] == target:
+            return 0
+        if len(nums) >= 2 and nums[1] == target:
+            return 1
+
+        left, right = 0, len(nums)-1
+
+        # 회전이 발생한 경우
+        while left <= right:
+            mid = (left+right)//2
+            curr = nums[mid]          # 현재 값
+            #print(f'{mid}: {curr}')
+            
+            if curr == target:
+                return mid
+            elif curr < target:
+                left += 1
+            else:       # target보다 큰 경우
+                diff_left = abs(target-nums[left])
+                diff_right = abs(target-nums[right])
+
+                if diff_left > diff_right and nums[left] > nums[right]:
+                    left += 1
+                else:
+                    right -= 1
+
+
+        return -1
+    '''

--- a/ch18/cmj_67_intersection_of_two_arrays.py
+++ b/ch18/cmj_67_intersection_of_two_arrays.py
@@ -1,0 +1,44 @@
+import collections
+
+class Solution:
+    def intersection(self, nums1: List[int], nums2: List[int]) -> List[int]:
+
+        # 두 배열의 {숫자: 개수} 저장
+        count1 = collections.defaultdict(int)
+        count2 = collections.defaultdict(int)
+
+        for num in nums1:
+            count1[num] += 1
+        for num in nums2:
+            count2[num] += 1
+
+        result = set()        # 결과 셋
+
+        # 숫자가 두 딕셔너리에 모두 있으면
+        for num in count1:
+            if num in count2:
+                result.add(num)
+        
+        return list(result)
+
+    def intersection2(self, nums1: List[int], nums2: List[int]) -> List[int]:
+        nums1.sort()
+        nums2.sort()
+
+        result = set()
+
+        # 투포인터
+        # 각각 nums1, nus2의 인덱스
+        i = j = 0
+
+        while i < len(nums1) and j < len(nums2):
+            if nums1[i] > nums2[j]:
+                j += 1
+            elif nums1[i] < nums2[j]:
+                i += 1
+            else:  # 같은 숫자가 있는 경우, 결과에 추가하고 두 배열 모두 오른쪽으로 이동
+                result.add(nums1[i])
+                i += 1
+                j += 1
+        
+        return list(result)

--- a/ch18/cmj_68_two_sum2-input_array_is_sorted.py
+++ b/ch18/cmj_68_two_sum2-input_array_is_sorted.py
@@ -1,0 +1,13 @@
+class Solution:
+    def twoSum(self, numbers: List[int], target: int) -> List[int]:
+        left, right = 0, len(numbers)-1
+
+        while left < right:
+            sum_ = numbers[left] + numbers[right]
+
+            if sum_ > target:
+                right -= 1
+            elif sum_ < target:
+                left += 1
+            else:
+                return [left+1, right+1]

--- a/ch18/cmj_69_search_a_2d_matrix2.py
+++ b/ch18/cmj_69_search_a_2d_matrix2.py
@@ -1,0 +1,51 @@
+class Solution:
+    # O(m+n)
+    def searchMatrix(self, matrix: List[List[int]], target: int) -> bool:
+        m, n=len(matrix), len(matrix[0])
+        i, j=0, n-1      #### 오른쪽 위에서 시작
+
+        while i<m and j>=0:
+            if matrix[i][j]==target:
+                return True
+            elif matrix[i][j]>target:       # 타겟보다 클 경우, 왼쪽으로 이동
+                j-=1
+            else:                           # 타겟보다 작을 경우, 아래 행으로 이동
+                i+=1
+        return False
+
+    
+
+''' 풀긴 풀었는데 40분 걸린 야매코드...   
+    def searchMatrix2(self, matrix: List[List[int]], target: int) -> bool:
+        
+        if len(matrix) == 1:
+            if target in matrix[0]:
+                return True
+            return False
+
+        left, right = 0, len(matrix[0])-1
+
+        i=0
+        while left <= right and i<len(matrix):
+            mid = (left+right)//2
+            curr = matrix[i][mid]
+
+            if curr > target:
+                right -= 1
+            elif curr < target:
+                left += 1
+            else:
+                return True
+
+            if matrix[i][(left+right)//2] == target:
+                return True
+            if left >= len(matrix[0]) or right >= len(matrix[0]):
+                left = 0
+                right = len(matrix[0])-1
+            if left == right:
+                left = 0
+                right = len(matrix[0])-1
+                i += 1
+
+        return False'''
+


### PR DESCRIPTION
### 65. [이진 검색](https://leetcode.com/problems/binary-search/)
문제 설명: 이진 검색을 이용해 주어진 배열에서 target을 찾는 문제
문제 풀이: 15분

풀이 방식
- 이진 검색
   - left, right: 배열의 왼쪽, 오른쪽을 나타내는 인덱스
   - mid: 배열의 중간값 (left+right)//2
   - nums[mid]가 target보다 작으면 left를, 크면 right을 mid를 기준으로 이동시킴
<br>

### 66. [회전 정렬된 배열 검색](https://leetcode.com/problems/search-in-rotated-sorted-array/)
문제 설명: 회전 정렬된 배열에서 이진 검색을 이용해 target을 찾는 문제
문제 미해결

풀이 방식
- 먼저, 회전이 이루어진 값의 인덱스인 pivot을 찾음
- 찾은 pivot을 이용해 이진 검색
   - mid_pivot = (mid+pivot)%len(nums)

느낀점
- 하나의 while문에서 pivot을 찾고 이진 검색을 같이 하려고 했더니 테케 5개를 통과하지 못했다...한꺼번에 해결하려고 하지 말고 쪼개서 해결하자
- mid_pivot을 왜 저렇게 조정해야하는지 잘 이해가 안간다
<br>

### 67. [두 배열의 교집합](https://leetcode.com/problems/intersection-of-two-arrays/)
문제 설명: 두 배열에서 공통으로 등장하는 원소를 구하는 문제
문제 풀이: 5분

풀이 방식
- 두 개의 딕셔너리로 각 배열의 원소 카운트를 저장
- 두 딕셔너리 모두에 원소가 있으면 결과에 추가

느낀점
- 책의 풀이로 보니 굳이 딕셔너리를 이용하는 것보다 투포인터를 이용하는 편이 더 간편하고 공간복잡도도 줄어드는 것 같다
- 근데 이 문제가 왜 이진 검색 문제인지 잘 모르겠다..
<br> 

### 69. [2D 행렬 검색 II](https://leetcode.com/problems/search-a-2d-matrix-ii/)
문제 설명: 각 행과 열이 정렬된 행렬에서 target을 찾는 문제
문제 풀이: 40분....

풀이 방식
- 행렬의 오른쪽 위에서부터 검색
  - 현재값이 target보다 크면 왼쪽으로 이동
  - 현재값이 target보다 작으면 아래로 이동
  - 최악의 경우 오른쪽 위에서 왼쪽 아래로 이동하므로 시간복잡도는 행+열: O(m+n)
<br>
