### PR TITLE
[Mijeong] ch09 question1-2

### DIFF
--- a/ch09_shortest-path/cmj_q1_future_city.py
+++ b/ch09_shortest-path/cmj_q1_future_city.py
@@ -1,0 +1,37 @@
+# 참고: https://velog.io/@kimdukbae/%ED%94%8C%EB%A1%9C%EC%9D%B4%EB%93%9C-%EC%9B%8C%EC%85%9C-%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-Floyd-Warshall-Algorithm
+# 다익스트라: 정해진 출발 지점에서 최단 경로를 구하는 경우에 사용
+# 플로이드 워셜: 모든 출발 지점에서 최단 경로를 구해야 하는 경우 사용
+    # 거쳐가는 노드를 기준으로 최단 거리 갱신
+class Solution:
+    def floyd_warshall(self):
+        INF = int(1e9)         # 10억
+
+        # N: 회사(노드)의 개수, M: 경로(엣지)의 개수
+        N, M = map(int, input().split())
+        graph = [[INF]*(N+1) for _ in range(N+1)]        # 노드별 최단거리를 저장하는 N*N 2차원 리스트
+
+        for i in range(1, N+1):
+            for j in range(1, N+1):
+                if i == j:
+                    graph[i][j] = 0        # 자기 자신과의 거리는 0
+
+        # 두 노드의 거리
+        for _ in range(M):
+            a, b = map(int, input().split())
+            graph[a][b] = 1
+            graph[b][a] = 1
+
+        # X: 최종 도착지점, K: 경유지
+        X, K = map(int, input().split())
+
+        for k in range(1, N+1):
+            for a in range(1, N+1):
+                for b in range(1, N+1):
+                    graph[a][b] = min(graph[a][b], graph[a][k] + graph[k][b])        # a -> b와 a -> k -> b 경로 중 최소를 택함
+
+        dist = graph[1][K] + graph[K][X]
+
+        print(dist) if dist < INF else print(-1)         # 갈 수 없는 경로인 경우 dist가 INF보다 커지므로 dist<INF로 비교해야 하는 것 주의
+
+s = Solution()
+s.floyd_warshall()

--- a/ch09_shortest-path/cmj_q2_telegram.py
+++ b/ch09_shortest-path/cmj_q2_telegram.py
@@ -1,0 +1,56 @@
+import heapq
+
+class Solution:
+    def dijkstra(self):
+        INF = int(1e9)
+
+        # N: 노드 개수, M: 간선 수, C: 시작 노드
+        N, M, C = map(int, input().split())
+        graph = [[] for i in range(N+1)]           # 각 노드 연결 정보를 저장
+        distance = [INF]*(N+1)                # 현재까지의 최단 경로 저장
+
+        for _ in range(M):
+            node1, node2, cost = map(int, input().split())
+            graph[node1].append((node2, cost))
+        #print(graph)
+
+        # 우선순위 큐
+        q = [] 
+        heapq.heappush(q, (0, C))       ### 우선순위 큐에 (거리, 노드) 형태로 저장. 이렇게하면 거리가 가까운 노드부터 큐에서 제거가능
+        distance[C] = 0         # 현재 거리 표시
+
+        while q:
+            dist, node = heapq.heappop(q)
+            
+            # 이미 방문한 경우
+            if dist > distance[node]:
+                continue
+            
+            # 연결되어 있는 노드 정보 확인
+            for next_node, next_dist in graph[node]:
+                # 연결된 노드까지의 거리
+                cost = dist + next_dist
+
+                # 새로운 거리가 해당 노드까지의 최단 거리보다 작으면, 최단 거리 갱신
+                if cost < distance[next_node]:
+                    distance[next_node] = cost
+                    heapq.heappush(q, (cost, next_node))
+
+        # city_count: 메시지를 전송할 수 있는 도시(노드)의 수
+        # arrival_time: 도시가 모두 메시지를 받는 데 걸리는 시간
+        city_count = 0
+        arrival_time = 0
+
+        for i in range(len(distance)):
+            if distance[i] != INF:
+                city_count += 1
+                arrival_time = max(arrival_time, distance[i])
+        
+        if city_count != 0:
+            print(city_count-1, arrival_time)         # city_count-1: 출발 도시 제외
+        else:
+            print("최단 경로 없음!")
+        
+
+s = Solution()
+s.dijkstra()


### PR DESCRIPTION
## 9장 최단 경로 알고리즘 문제풀이.

### 🍪문제 번호 : 실전문제 2. 미래 도시

🍈문제 정의 : 노드 개수, 엣지 개수, 연결된 노드들의 정보가 주어질 때, 방문 판매원이 1에서 출발해 K를 거쳐 X로 가는 최단 경로의 길이를 구하는 문제

🍊풀이 시간 : 55분

🍒풀이 방법 :
- 플로이드-워셜 최단 경로: 모든 출발 지점에서의 최단 경로를 구할 때 사용
   - 2차원 리스트 graph에 노드별 거리를 저장. 자기 자신과의 거리는 0으로 갱신
   - 모든 출발, 도착 노드 a, b에 대해 **a-b거리와 k를 거쳐서 가는 a-k-b 거리 중 최단 거리를 갱신**
   - 점화식: **graph[a][b] = min(graph[a][b], graph[a][k] + graph[k][b])**
   - K를 거쳐 X로 가는 최단 경로: graph[1][K] + graph[K][X]
<br>

### 🍪문제 번호 : 실전문제 3. 전보

🍈문제 정의 : 노드 개수, 엣지 개수, 출발 도시 C, 연결된 노드들의 정보가 주어질 때, C에서 보낸 메시지를 받는 도시의 총 개수와 이 도시들이 메시지를 받는데 걸리는 총 시간을 구하는 문제

🍊풀이 시간 : 60분...미해결

🍒풀이 방법 :
- 다익스트라 최단 경로
   1. 우선순위 큐 사용X: 노드 방문 여부를 boolean리스트인 visited로 확인
       - 시간복잡도: O(V2) &nbsp; &nbsp; &nbsp; &nbsp; (V: 노드의 개수)
   2. 우선순위 큐 사용: visited 리스트 사용할 필요 없이 값으로 방문 여부 확인 가능
       - 시간복잡도: O(ElogV)  &nbsp; &nbsp;  &nbsp; &nbsp;(V: 노드의 개수, E: 간선의 개수)
       -  1차원 리스트 graph에 (현재 노드와 연결된 노드, 거리) 를 저장
       - distance: 현재 노드까지의 최단 경로를 저장하는 리스트. INF(10억)값으로 초기화
       
       - 우선순위 큐에 (거리, 노드) 형태로 값을 push, pop함    ->  거리가 가까운 노드를 큐에서 먼저 제거할 수 있음
       - 우선순위 큐에서 pop한 노드의 거리가 distance[node]보다 크면 해당 경로는 이미 방문한 것이므로 continue
       - 큐에서 제거한 현재 노드와 연결된 노드 확인
          - 연결된 노드까지의 거리가 연결된 노드의 최단 경로(distance[node])보다 작으면, 
          - 최단 거리를 갱신하고 우선순위 큐에 push

- 이 문제의 경우, C에서 보낸 메시지를 받은 도시의 수와 총 시간을 구해야 하므로
- C에서 보낸 메시지를 받은 도시의 수: distance에서 갱신된 노드의 개수-1 (출발 노드 제외)
- 총 시간: distance에서 갱신된 노드의 max값