### PR TITLE
[Mijeong] ch17 question37-40

### DIFF
--- a/PreviousQuestions/cmj_q37_floyd.py
+++ b/PreviousQuestions/cmj_q37_floyd.py
@@ -1,0 +1,33 @@
+class Solution:
+    def floyd(self):
+        n = int(input())     # 도시 수
+        m = int(input())     # 버스 수
+        
+        graph = [[float("inf")]*(n) for _ in range(n)]        # 모든 노드들간의 거리를 무한대값으로 설정정
+        
+        for i in range(n):
+            for j in range(n):
+                if i == j:
+                    graph[i][j] = 0       # 자기 자신과의 거리는 0
+
+        for _ in range(m):
+            a, b, cost = map(int, input().split())
+            
+            graph[a-1][b-1] = min(cost, graph[a-1][b-1])      # 시작도시와 도착도시를 연결하는 간선은 1개 이상이므로 그 중 최소 비용을 저장
+
+        ## 플로이드 워셜
+        for k in range(n):
+            for i in range(n):
+                for j in range(n):
+                    graph[i][j] = min(graph[i][j], graph[i][k] + graph[k][j])    # i->j와 k를 거쳐서 가는 i->k->j 중 최소를 택함
+        
+        # 결과 출력력
+        for line in graph:
+            for item in line:
+                if item == float("inf"):       # 갈 수 없는 경로는 0으로 설정
+                    item = 0
+                print(item, end=' ')
+            print()
+
+s = Solution()
+s.floyd()

--- a/PreviousQuestions/cmj_q38_accurate_ranking.py
+++ b/PreviousQuestions/cmj_q38_accurate_ranking.py
@@ -1,0 +1,51 @@
+class Solution:
+    def ranking(self):
+        '''
+            임의의 두 학생간의 상대 순위만 쌍으로 주어질 때,
+            성적을 확실히 알 수 있는 학생의 수를 구하는 문제
+            
+            성적을 확실히 알 수 있음 
+            -> 모든 노드가 해당 노드와 직간접적으로 연결되어 있다 (이걸 생각을 못했다)
+            => 즉, 거쳐가는 노드를 고려해야 하는 최단 경로 문제
+            다익스트라: 시작 노드가 정해져있을 때의 최단 경로 ex) A에서 시작하는 최단경로
+            플로이드-워셜: 모든 노드를 고려한 최단 경로 
+            => 이 문제는 플로이드-워셜을 이용한 최단경로 문제다
+            
+        '''
+        # N: 학생 수, M: 학생 성적 비교(간선)
+        N, M = map(int, input().split())
+
+        graph = [[float("inf")]*(N+1) for _ in range(N+1)]         # 초기 거리는 inf(무한대)로 설정
+
+        for i in range(N+1):
+            for j in range(N+1):
+                if i == j:
+                    graph[i][j] = 0             # 자기 자신과의 거리는 0
+        
+        for _ in range(M):
+            a, b = map(int, input().split())
+            graph[a][b] = 1                # 연결된 노드의 거리는 1
+        
+        
+        ## 플로이드-워셜
+        # 노드 a-b 사이의 거리를 구하는데, 거쳐가는 중간 노드를 고려
+        # k노드를 거쳐갈 때와 거쳐가지 않을 때 중 최소를 택함
+        for k in range(1, N+1):
+            for a in range(1, N+1):
+                for b in range(1, N+1):
+                    graph[a][b] = min(graph[a][b], graph[a][k] + graph[k][b])
+
+        # 각 학생을 번호에 따라 한 명씩 확인하며 도달 가능한지 체크
+        result = 0
+        for i in range(1, N+1):
+            count = 0        # 노드 i와 나머지 노드들과의 연결을 카운트
+            for j in range(1, N+1):
+                # i와 j 노드가 연결되어 있으면 카운트 증가
+                if graph[i][j] != float("inf") or graph[j][i] != float("inf"):
+                    count += 1
+            if count == N:    # 카운트가 N이 되면, 즉 i와 다른 노드들이 모두 연결되어 있으면 result 증가
+                result += 1
+        print(result)
+
+s = Solution()
+s.ranking()

--- a/PreviousQuestions/cmj_q39_mars_explore.py
+++ b/PreviousQuestions/cmj_q39_mars_explore.py
@@ -1,0 +1,51 @@
+import heapq
+class Solution:
+    def explore(self):
+        # T: 테스트 케이스 수
+            # N: 탐사 공간 크기
+            # 각 칸의 비용
+
+        dx = [-1, 0, 1, 0]
+        dy = [0, 1, 0, -1]
+        INF = int(1e9)
+        # 전체 테스트 케이스(Test Case)만큼 반복
+        for tc in range(int(input())):
+            # 노드의 개수를 입력받기
+            n = int(input())
+
+            # 전체 맵 정보를 입력받기
+            graph = []
+            for i in range(n):
+                graph.append(list(map(int, input().split())))
+
+            # 최단 거리 테이블을 모두 무한으로 초기화
+            distance = [[INF] * n for _ in range(n)]
+
+            x, y = 0, 0 # 시작 위치는 (0, 0)
+            # 시작 노드로 가기 위한 비용은 (0, 0) 위치의 값으로 설정하여, 큐에 삽입
+            q = [(graph[x][y], x, y)]
+            distance[x][y] = graph[x][y]
+
+            # 다익스트라 알고리즘을 수행
+            while q:
+                # 가장 최단 거리가 짧은 노드에 대한 정보를 꺼내기
+                dist, x, y = heapq.heappop(q)
+                # 현재 노드가 이미 처리된 적이 있는 노드라면 무시
+                if distance[x][y] < dist:
+                    continue
+                # 현재 노드와 연결된 다른 인접한 노드들을 확인
+                for i in range(4):
+                    nx = x + dx[i]
+                    ny = y + dy[i]
+                    # 맵의 범위를 벗어나는 경우 무시
+                    if nx < 0 or nx >= n or ny < 0 or ny >= n:
+                        continue
+                    cost = dist + graph[nx][ny]
+                    # 현재 노드를 거쳐서, 다른 노드로 이동하는 거리가 더 짧은 경우
+                    if cost < distance[nx][ny]:
+                        distance[nx][ny] = cost
+                        heapq.heappush(q, (cost, nx, ny))
+
+            print(distance[n - 1][n - 1])
+s = Solution()
+s.explore()

--- a/PreviousQuestions/cmj_q40_hide_and_seek.py
+++ b/PreviousQuestions/cmj_q40_hide_and_seek.py
@@ -1,0 +1,60 @@
+import heapq
+class Solution:
+    def find_spot(self):
+        # N: 헛간 개수, M: 통로(간선)
+        N, M = map(int, input().split())
+
+        # 1번 헛간으로 부터 가장 먼 헛간 구하기
+        # 숨어야 하는 헛간 번호, 그 헛간까지의 거리, 그 헛간과 같은 거리를 갖는 헛간의 개수 구하기
+        INF = int(1e9)
+        graph = [[INF]*(N+1) for _ in range(N+1)]
+        distance = [INF]*(N+1)
+
+        for _ in range(M):
+            a, b = map(int, input().split())
+            graph[a][b] = 1        # 두 노드가 연결되어 있음을 표시, 양방향
+            graph[b][a] = 1
+
+        q = [(0, 1)]       # 거리, 헛간 번호
+        distance[1] = 0        # 현재 노드의 거리를 0으로 갱신
+
+        while q:
+            dist, curr = heapq.heappop(q)
+
+            # 현재 노드 a의 최단거리보다 더 크면 넘어감
+            if distance[curr] < dist:
+                continue
+            
+            # curr와 연결된 노드 확인
+            for next_node, next_dist in enumerate(graph[curr]):
+                if next_dist == INF:        # 갈 수 없는 노드는 넘어감
+                    continue
+
+                # 연결된 노드까지의 거리
+                new_dist = dist + next_dist
+
+                if new_dist < distance[next_node]:         # new_dist가 기존 next_node의 최단 거리보다 작으면, 갱신
+                    distance[next_node] = new_dist
+                    heapq.heappush(q, (new_dist, next_node))          # 큐에 다음에 방문할 노드로 추가
+        print(distance)
+        
+        # 숨어야 하는 헛간 = 노드 1에서 가장 먼 헛간
+        # 근데, 거리가 같은 헛간이 여러개면 가장 작은 번호 출력
+
+        max_idx = 0        # 헛간 번호
+        max_dist = 0       # 헛간까지의 거리
+        count = 1         # 거리가 같은 헛간의 개수, 자기 자신도 포함해야 하므로 1로 초기화
+        for i in range(1, len(distance)):
+            if distance[i] == INF:
+                continue
+            
+            if max_dist < distance[i]:
+                count = 1          # 더 큰 값이 나타나면 count값 초기화
+                max_idx = i
+                max_dist = distance[i]
+
+            elif max_dist == distance[i]:
+                count += 1
+        print(max_idx, max_dist, count)
+s = Solution()
+s.find_spot()


### PR DESCRIPTION
## 17장 최단 경로 알고리즘 문제풀이.

### 🍪문제 번호 : 37. 플로이드

🍈문제 정의 : 도시가 n개, 도시를 연결하는 버스(간선)가 m개가 [도시 a, 도시 b, 비용] 의 형태로 주어질 때, 모든 도시 쌍 (a, b)에 대해 a에서 b로 가는 최소 비용을 구하는 문제

🍊풀이 시간 : 45분

🍒풀이 방법 :
- 플로이드 워셜
  - graph: 모든 도시 쌍 (a, b)의 거리를 무한대로 초기화 (단, 자기 자신과의 거리는 0)
  - 모든 버스 정보(a, b, cost)에 대해 graph[a][b] = min(cost, graph[a][b])로 갱신 (a, b를 연결하는 간선이 1개 이상이므로)
  - 모든 중간 노드 k에 대해
     - graph[a][b] = min(graph[a][b], graph[a][k]+graph[k][b])로 갱신
  
느낀점
- 문제에서 i에서 j로 가는 경로가 없으면 0을 출력하라고 했는데, 문제를 잘 안 읽어서 이 부분을 놓쳤다..
<br>
 
### 🍪문제 번호 : 38. 정확한 순위

🍈문제 정의 :  임의의 두 학생간의 상대 순위만 쌍으로 주어질 때, 성적을 확실히 알 수 있는 학생의 수를 구하는 문제

🍊풀이 시간 : 미해결..

🍒풀이 방법 :
- 플로이드 워셜 사용
   - 출발 노드가 정해지지 않았고(출발 노드가 정해져있으면 다익스트라)
   - 성적을 확실히 알 수 있는 학생 = 모든 노드가 해당 노드와 직간접적으로 연결되어 있다는 것
   => 즉, 거쳐가는 노드를 고려해야 하는 최단 경로 문제라는 것...을 생각못했다

- 앞 문제와 같이 플로이드 워셜로 모든 노드의 최단 경로를 구한 다음
- 모든 노드 i와 i와 연결된 j노드에 대해 거리 값이 무한대가 아니면 count 증가
- 이 count값이 N이 되면 -> 현재 노드 i가 모든 노드와 연결되어 있다는 것이므로 result 증가
<br>

### 🍪문제 번호 : 39. 화성 탐사

🍈문제 정의 :  N*N 공간에서 [0][0] 위치에서 [N-1][N-1]로 가는 최소 비용 구하기

🍊풀이 시간 : 미해결..

🍒풀이 방법 :
- 다익스트라+방향벡터?
   - distance: 최단거리를 저장하는 2차원 리스트, 무한대로 초기화
   - dx, dy: 상하좌우를 나타내는 방향 벡터
   - 기존 다익스트라 코드(우선순위큐 사용)에 dx, dy를 이용해 경곗값을 넘어가는지 확인하는 부분 추가
<br>

### 🍪문제 번호 : 40. 숨바꼭질

🍈문제 정의 :  헛간 N개와 통로 M개가 주어지고, 연결된 헛간 번호 (a, b) 쌍이 주어질 때 1번 헛간으로부터 가장 먼 헛간의 번호, 해당 헛간까지의 거리, 해당 헛간과 거리가 같은 헛간 개수 구하기 (단, 거리가 같은 헛간이 여러개면 가장 작은 번호 출력)

🍊풀이 시간 : 45분

🍒풀이 방법 :
- 다익스트라
   - distance: 최단거리를 저장하는 1차원 리스트 (헛간이 1차원 데이터이므로)
   - graph: 헛간 (a, b)쌍의 연결을 표시. 연결된 헛간은 1, 그렇지 않으면 무한대 (근데 이제 생각해보니 무한대로 굳이 설정 안해도 될 듯...)
   - 기존 다익스트라 코드 사용
      - 큐에서 꺼낸 노드의 거리가 최단 거리(distance[i])보다 크면 넘어감
      - 더 작으면, 현재 노드와 연결된 노드 확인
      - 연결된 노드까지의 거리가 distance[next_node]보다 작으면, 최단 거리 갱신하고 큐에 방문할 노드로 추가